### PR TITLE
Removal of master/slave lingo

### DIFF
--- a/examples/ModbusSerial/main.py
+++ b/examples/ModbusSerial/main.py
@@ -13,21 +13,21 @@ try:
     device = rs485.RS485(100000)
     # Wait for the serial port to open. This may not be necessary
     sleep(10000)
-    master = modbus.ModbusSerial(1, serial_device = device)
+    main = modbus.ModbusSerial(1, serial_device = device)
 
-    result = master.write_register(5, 745)
+    result = main.write_register(5, 745)
     print("Written discrete register: ", result)
 
-    result = master.write_multiple_registers(2, 4, [55, 555, 123, 42])
+    result = main.write_multiple_registers(2, 4, [55, 555, 123, 42])
     print("Written ", result, " registers")
 
-    discrete = master.read_discrete(2, 4)
+    discrete = main.read_discrete(2, 4)
     print("Discrete inputs values: ", discrete)
 
-    holding = master.read_holding(3, 2)
+    holding = main.read_holding(3, 2)
     print("Holding registers values: ", holding)
 
-    master.close()
+    main.close()
     print("Closed.")
 	
 except Exception as e:

--- a/examples/ModbusTcp/main.py
+++ b/examples/ModbusTcp/main.py
@@ -22,39 +22,39 @@ try:
     except Exception as e:
         print("Exception while trying to connect to the network ", e)
             
-    master = modbus.ModbusTCP(1)
+    main = modbus.ModbusTCP(1)
 
     try:
-        master.connect("ip-address")
+        main.connect("ip-address")
         print("Connected.")
     except Exception as e:
-        print("Couldn't connect to the slave device ", e)
+        print("Couldn't connect to the subordinate device ", e)
 
-    result = master.write_coil(2, 0xff00)
+    result = main.write_coil(2, 0xff00)
     print("Written coil 2: ", result)
 
-    result = master.write_register(55, 745)
+    result = main.write_register(55, 745)
     print("Written discrete register: ", result)
 
-    result = master.write_multiple_coils(10, 10, [1, 0, 1, 1, 0, 0, 1, 1, 1, 0])
+    result = main.write_multiple_coils(10, 10, [1, 0, 1, 1, 0, 0, 1, 1, 1, 0])
     print("Written ", result, " coils")
 
-    result = master.write_multiple_registers(20, 10, [55, 555, 123, 42, 352, 546, 754, 34, 643, 23])
+    result = main.write_multiple_registers(20, 10, [55, 555, 123, 42, 352, 546, 754, 34, 643, 23])
     print("Written ", result, " registers")
 
-    coils = master.read_coils(20, 19)
+    coils = main.read_coils(20, 19)
     print("Coils 20-38 status: ", coils)
 
-    discrete = master.read_discrete(20, 15)
+    discrete = main.read_discrete(20, 15)
     print("Discrete inputs 20-34 values: ", discrete)
 
-    holding = master.read_holding(20, 10)
+    holding = main.read_holding(20, 10)
     print("Holding registers 20-29 values: ", holding)
 
-    inputs = master.read_input(20, 10)
+    inputs = main.read_input(20, 10)
     print("Input registers 20-29 values: ", inputs)
 
-    master.close()
+    main.close()
     print("Closed.")
 	
 except Exception as e:

--- a/modbus.py
+++ b/modbus.py
@@ -4,7 +4,7 @@
 ***************
 MODBUS Library
 ***************
-    To talk with a slave device an object of type ModbusTCP or ModbusSerial must be\
+    To talk with a subordinate device an object of type ModbusTCP or ModbusSerial must be\
         initialized, depending on what kind of communication is needed.
 
     If serial communication is used, a device object that implements write, read and close methods is needed:
@@ -59,7 +59,7 @@ MODBUS Library
                 self.port.close()
         
         
-    When a connection with a slave device has been established, coils and registers can be accessed with the methods in each class.
+    When a connection with a subordinate device has been established, coils and registers can be accessed with the methods in each class.
 
     """
 
@@ -242,9 +242,9 @@ ModbusTCP class
 
 .. class:: ModbusTCP(identifier)
 
-    Create an instance of the ModbusTCP class which allow modbus communication with slave device using TCP.
+    Create an instance of the ModbusTCP class which allow modbus communication with subordinate device using TCP.
     
-    :param identifier: The slave device identifier, used in the header of every packet.
+    :param identifier: The subordinate device identifier, used in the header of every packet.
 
     """
     def __init__(self, identifier):
@@ -488,7 +488,7 @@ ModbusTCP class
         return pdu
 
     def _send_tcp(self, endpoint, pdu):
-        # 2 bytes (TransmissionID) + 2 bytes (Protocol ID) + 2 bytes (Length) + 1 byte (Slave Device ID) + N bytes (pdu) + 2 bytes (CRC)
+        # 2 bytes (TransmissionID) + 2 bytes (Protocol ID) + 2 bytes (Length) + 1 byte (Subordinate Device ID) + N bytes (pdu) + 2 bytes (CRC)
         packet = bytearray(7 + len(pdu))
         bs = bytes_to_bytearray(self.transmissionID)
         # Transmission ID
@@ -501,7 +501,7 @@ ModbusTCP class
         length = bytes_to_bytearray(len(pdu) + 1)
         packet[4] = length[0]
         packet[5] = length[1]
-        # Slave Device ID
+        # Subordinate Device ID
         packet[6] = endpoint
         # PDU
         packet[7:] = pdu
@@ -512,8 +512,8 @@ ModbusTCP class
         """
         .. method:: connect(address, [port = 502])
             
-            :param address: the ip address of the slave device
-            :param port: port on which the slave device is listening to
+            :param address: the ip address of the subordinate device
+            :param port: port on which the subordinate device is listening to
         """
         self._socket.connect((address, port))
         
@@ -521,7 +521,7 @@ ModbusTCP class
         """
         .. method:: close()
 
-            close the connection with the slave device 
+            close the connection with the subordinate device 
 
         """
         self._socket.close()
@@ -536,9 +536,9 @@ ModbusSerial class
 
 .. class:: ModbusSerial(identifier, serial_device)
 
-    Create an instance of the ModbusSerial class which allow modbus communication with slave device using RTU.
+    Create an instance of the ModbusSerial class which allow modbus communication with subordinate device using RTU.
     
-    :param identifier: The slave device identifier
+    :param identifier: The subordinate device identifier
 
     :param serial_device: an object representing the device. It must implement read, write and close methods to \
         communicate with the serial port. See **rs485** in the example folder.


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.